### PR TITLE
Feature/wit ros imu

### DIFF
--- a/igvc2023/launch/sensors.launch
+++ b/igvc2023/launch/sensors.launch
@@ -12,6 +12,10 @@
     <arg name="gps2_dev"         default="/dev/sensors/GNSSrover"/>
     <arg name="use_ekf"          default="true"/>
     <arg name="urg_ip"           default="192.168.3.11"/>
+
+    <arg name="use_wit_imu"      default="false"/>
+    <arg name="type"             default="normal" doc="type [normal, modbus]"/>
+    <arg name="wit_imu_dev"      default="/dev/ttyUSB0"/>
     
     
     <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
@@ -24,10 +28,16 @@
         <param name="use_gui" value="true"/>
         <param name="rate"    value="50"/>
     </node>
-    
-    
+
+    <!-- wit_imu python -->
+    <node if="$(arg use_wit_imu)" pkg="wit_ros_imu" type="wit_$(arg type)_ros.py" name="imu" output="screen">
+        <remap from="wit/imu" to="imu"/>
+        <param name="port" type = "str" value="$(arg wit_imu_dev)"/>
+        <param name="baud" type = "int" value="9600"/>
+    </node>
+
     <!-- Node to setting up Arduino serial communication for IMU sensor -->
-    <node pkg="rosserial_python" type="serial_node.py" name="serial_node_IMU">
+    <node unless="$(arg use_wit_imu)" pkg="rosserial_python" type="serial_node.py" name="serial_node_IMU">
         <param name="port" value="$(arg imu_dev)"/>
         <param name="baud" value="115200"/>
     </node>

--- a/igvc2023/package.xml
+++ b/igvc2023/package.xml
@@ -31,6 +31,7 @@
   <exec_depend>nmea_navsat_driver</exec_depend>
   <exec_depend>cv_camera</exec_depend>
   <exec_depend>robot_pose_ekf</exec_depend>
+  <exec_depend>wit_ros_imu</exec_depend>
   <export>
     <gazebo_ros gazebo_media_path="${prefix}/world"/>
     <gazebo_ros gazebo_model_path="${prefix}/models"/>

--- a/wit_ros_imu/CMakeLists.txt
+++ b/wit_ros_imu/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(wit_ros_imu)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  rospy
+  std_msgs
+)
+
+catkin_package()
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+install(DIRECTORY demo driver robot_para rviz
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+

--- a/wit_ros_imu/launch/rviz_and_imu.launch
+++ b/wit_ros_imu/launch/rviz_and_imu.launch
@@ -1,0 +1,18 @@
+
+<!-- open imu and rviz -->
+<launch>
+
+    <!-- imu type, default normal -->
+    <arg name="type" default="normal" doc="type [normal, modbus]"/>
+
+    <!-- imu python -->
+    <node pkg="wit_ros_imu" type="wit_$(arg type)_ros.py" name="imu" output="screen">
+        <param name="port"               type = "str"    value="/dev/ttyUSB0"/>
+        <param name="baud"               type = "int"    value="9600"/>
+    </node>
+
+    <!-- load rviz -->
+    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find wit_ros_imu)/rviz/wit_ros_imu.rviz">
+    </node>
+
+</launch>   

--- a/wit_ros_imu/package.xml
+++ b/wit_ros_imu/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package>
+  <name>wit_ros_imu</name>
+  <version>1.0.1</version>
+  <description>The ros_imu package</description>
+
+  <maintainer email="yahboom@todo.todo">yahboom</maintainer>
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+
+  <export>
+
+  </export>
+</package>

--- a/wit_ros_imu/rviz/wit_ros_imu.rviz
+++ b/wit_ros_imu/rviz/wit_ros_imu.rviz
@@ -1,0 +1,222 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Odometry1/Shape1
+        - /Imu1/Box properties1
+      Splitter Ratio: 0.587896228
+    Tree Height: 581
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679016
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: LaserScan
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Angle Tolerance: 0.100000001
+      Class: rviz/Odometry
+      Covariance:
+        Orientation:
+          Alpha: 0.5
+          Color: 255; 255; 127
+          Color Style: Unique
+          Frame: Local
+          Offset: 1
+          Scale: 1
+          Value: true
+        Position:
+          Alpha: 0.300000012
+          Color: 204; 51; 204
+          Scale: 1
+          Value: true
+        Value: false
+      Enabled: true
+      Keep: 10000
+      Name: Odometry
+      Position Tolerance: 0.100000001
+      Shape:
+        Alpha: 1
+        Axes Length: 1
+        Axes Radius: 0.100000001
+        Color: 255; 255; 0
+        Head Length: 0.300000012
+        Head Radius: 0.100000001
+        Shaft Length: 1
+        Shaft Radius: 0.0500000007
+        Value: Arrow
+      Topic: /mobile_base/mobile_base_controller/odom
+      Unreliable: false
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base_link:
+          Value: true
+        laser:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        base_link:
+          laser:
+            {}
+      Update Interval: 0
+      Value: true
+    - Acceleration properties:
+        Acc. vector alpha: 1
+        Acc. vector color: 255; 0; 0
+        Acc. vector scale: 1
+        Derotate acceleration: true
+        Enable acceleration: false
+      Axes properties:
+        Axes scale: 2
+        Enable axes: true
+      Box properties:
+        Box alpha: 1
+        Box color: 255; 0; 0
+        Enable box: true
+        x_scale: 2
+        y_scale: 1
+        z_scale: 1
+      Class: rviz_imu_plugin/Imu
+      Enabled: true
+      Name: Imu
+      Topic: /wit/imu
+      Unreliable: false
+      Value: true
+      fixed_frame_orientation: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/LaserScan
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 47
+      Min Color: 0; 0; 0
+      Min Intensity: 47
+      Name: LaserScan
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.0299999993
+      Style: Flat Squares
+      Topic: /scan
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 6.55897284
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.0431831963
+        Y: -0.558661819
+        Z: -0.0496840663
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.0500000007
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Pitch: 1.56979632
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 3.14038801
+    Saved: ~
+Window Geometry:
+  Camera:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 716
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000286fc020000000bfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002800000286000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006100000001d1000000b50000001600000016fb0000000c00430061006d0065007200610000000236000000940000001600000016fb0000000c00430061006d00650072006101000002f7000000ca0000000000000000000000010000010f0000025efc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007300000000280000025e000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000005210000003bfc0100000002fb0000000800540069006d00650000000000000005210000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000003b10000028600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1313
+  X: 53
+  Y: 24

--- a/wit_ros_imu/scripts/wit_normal_ros.py
+++ b/wit_ros_imu/scripts/wit_normal_ros.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+import serial
+import struct
+import rospy
+import math
+import platform
+import serial.tools.list_ports
+from sensor_msgs.msg import Imu
+from sensor_msgs.msg import MagneticField
+from tf.transformations import quaternion_from_euler
+
+
+
+def checkSum(list_data, check_data):
+    return sum(list_data) & 0xff == check_data
+
+
+def hex_to_short(raw_data):
+    return list(struct.unpack("hhhh", bytearray(raw_data)))
+
+
+# Parsing serial Port Data
+def handleSerialData(raw_data):
+    global buff, key, angle_degree, magnetometer, acceleration, angularVelocity, pub_flag
+    angle_flag=False
+    if python_version == '2':
+        buff[key] = ord(raw_data)
+    if python_version == '3':
+        buff[key] = raw_data
+
+    key += 1
+    if buff[0] != 0x55:
+        key = 0
+        return
+    # According to the judgment of the data length bit, the corresponding length data can be obtained
+    if key < 11:
+        return
+    else:
+        data_buff = list(buff.values())  # Get dictionary ownership value
+        if buff[1] == 0x51 :
+            if checkSum(data_buff[0:10], data_buff[10]):
+                acceleration = [hex_to_short(data_buff[2:10])[i] / 32768.0 * 16 * 9.8 for i in range(0, 3)]
+            else:
+                print('0x51 Check failure')
+
+        elif buff[1] == 0x52:
+            if checkSum(data_buff[0:10], data_buff[10]):
+                angularVelocity = [hex_to_short(data_buff[2:10])[i] / 32768.0 * 2000 * math.pi / 180 for i in range(0, 3)]
+
+            else:
+                print('0x52 Check failure')
+
+        elif buff[1] == 0x53:
+            if checkSum(data_buff[0:10], data_buff[10]):
+                angle_degree = [hex_to_short(data_buff[2:10])[i] / 32768.0 * 180 for i in range(0, 3)]
+                angle_flag = True
+            else:
+                print('0x53 Check failure')
+        elif buff[1] == 0x54:
+            if checkSum(data_buff[0:10], data_buff[10]):
+                magnetometer = hex_to_short(data_buff[2:10])
+            else:
+                print('0x54 Check failure')
+        else:
+            buff = {}
+            key = 0
+
+        buff = {}
+        key = 0
+        if angle_flag:                
+            stamp = rospy.get_rostime()
+
+            imu_msg.header.stamp = stamp
+            imu_msg.header.frame_id = "base_link"
+
+            mag_msg.header.stamp = stamp
+            mag_msg.header.frame_id = "base_link"
+
+            angle_radian = [angle_degree[i] * math.pi / 180 for i in range(3)]
+            qua = quaternion_from_euler(angle_radian[0], angle_radian[1], angle_radian[2])
+
+            imu_msg.orientation.x = qua[0]
+            imu_msg.orientation.y = qua[1]
+            imu_msg.orientation.z = qua[2]
+            imu_msg.orientation.w = qua[3]
+
+            imu_msg.angular_velocity.x = angularVelocity[0]
+            imu_msg.angular_velocity.y = angularVelocity[1]
+            imu_msg.angular_velocity.z = angularVelocity[2]
+
+            imu_msg.linear_acceleration.x = acceleration[0]
+            imu_msg.linear_acceleration.y = acceleration[1]
+            imu_msg.linear_acceleration.z = acceleration[2]
+
+            mag_msg.magnetic_field.x = magnetometer[0]
+            mag_msg.magnetic_field.y = magnetometer[1]
+            mag_msg.magnetic_field.z = magnetometer[2]
+
+            imu_pub.publish(imu_msg)
+            mag_pub.publish(mag_msg)
+
+
+key = 0
+flag = 0
+buff = {}
+angularVelocity = [0, 0, 0]
+acceleration = [0, 0, 0]
+magnetometer = [0, 0, 0]
+angle_degree = [0, 0, 0]
+
+
+if __name__ == "__main__":
+    python_version = platform.python_version()[0]
+
+    rospy.init_node("imu")
+    port = rospy.get_param("~port", "/dev/ttyUSB0")
+    baudrate = rospy.get_param("~baud", 9600)
+    print("IMU Type: Normal Port:%s baud:%d" %(port,baudrate))
+    imu_msg = Imu()
+    mag_msg = MagneticField()
+    try:
+        wt_imu = serial.Serial(port=port, baudrate=baudrate, timeout=0.5)
+        if wt_imu.isOpen():
+            rospy.loginfo("\033[32mSerial port opened successfully...\033[0m")
+        else:
+            wt_imu.open()
+            rospy.loginfo("\033[32mSerial port opened successfully...\033[0m")
+    except Exception as e:
+        print(e)
+        rospy.loginfo("\033[31mSerial port opening failure\033[0m")
+        exit(0)
+    else:
+        imu_pub = rospy.Publisher("wit/imu", Imu, queue_size=10)
+        mag_pub = rospy.Publisher("wit/mag", MagneticField, queue_size=10)
+
+        while not rospy.is_shutdown():
+            try:
+                buff_count = wt_imu.inWaiting()
+            except Exception as e:
+                print("exception:" + str(e))
+                print("imu disconnect")
+                exit(0)
+            else:
+                if buff_count > 0:
+                    buff_data = wt_imu.read(buff_count)
+                    for i in range(0, buff_count):
+                        handleSerialData(buff_data[i])
+

--- a/wit_ros_imu/scripts/wit_normal_ros.py
+++ b/wit_ros_imu/scripts/wit_normal_ros.py
@@ -72,10 +72,10 @@ def handleSerialData(raw_data):
             stamp = rospy.get_rostime()
 
             imu_msg.header.stamp = stamp
-            imu_msg.header.frame_id = "base_link"
+            imu_msg.header.frame_id = "imu_link"
 
             mag_msg.header.stamp = stamp
-            mag_msg.header.frame_id = "base_link"
+            mag_msg.header.frame_id = "mag_link"
 
             angle_radian = [angle_degree[i] * math.pi / 180 for i in range(3)]
             qua = quaternion_from_euler(angle_radian[0], angle_radian[1], angle_radian[2])


### PR DESCRIPTION
## 概要

- ICM-20948が調子悪いとのことなので応急処置的に10軸IMUのCMP10Aを利用できるように、依存パッケージを追加しました。

### やったこと

- wit_ros_imuパッケージの追加と`sensors.launch`への加筆。

### できるようになること

- `sensors.launch`を起動する際に、`use_wit_imu`を`true`にすることでICM-20948ではなく、CMP10AをROSで利用できるようになります。

### その他
<!-- レビューアーに確認してもらいたいこと -->

- CMP10Aのデバイス名は`/dev/ttyUSB0`と仮置きしているので必要に応じてdefaultタグを変更してください。
- 実機で動作確認をしていないので、本番前に必ず動くかの確認をお願いします。
